### PR TITLE
Fix Anaconda Cloud upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 - conda install python=$TRAVIS_PYTHON_VERSION
 - conda install -q conda-build anaconda-client coverage sphinx
 script:
-- conda build ./recipe -c csdms-stack -c conda-forge --old-build-string
+- conda build ./recipe -c csdms-stack -c conda-forge
 after_success:
 - curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py
   > $HOME/anaconda_upload.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,7 @@ package:
 
 source:
   git_url: https://github.com/GeoscienceAustralia/anuga_core
+  git_rev: {{ version }}
 
 requirements:
   build:


### PR DESCRIPTION
Although the recipe was built correctly, the upload to Anaconda Cloud was failing because of a change in behavior between conda-build 2 and 3. In the end, we decided to go with the conda-build 3 naming convention, and @mcflugen updated the upload script.